### PR TITLE
Add AGENTS file and wrap README file tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ phpstorm.meta.php
 # PHPUnit / coverage
 coverage/
 
+.phpunit.result.cache

--- a/AGENTS.mb
+++ b/AGENTS.mb
@@ -1,0 +1,8 @@
+## Agents
+
+### \xf0\x9f\xa7\xa0 Codex-Ae
+- **Role**: General assistant for coding, doc editing, testing, and refactoring.
+- **Trigger**: Via Codex UI or `.codex/tasks.json`
+- **Scope**: Full access to project files.
+- **Limitations**: No internet access unless configured via plugin.
+- **Token**: Injected via environment (GH_TOKEN, OPENAI_KEY)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Typical first-run workflow:
 ![Screenshot of Mobi Skeleton Homepage](img/screenshot.webp)
 
 ## File Structure
+<pre>
 .
 ├── index.php            # Entry point
 ├── mbstyle.css          # Shared dark theme CSS
@@ -72,6 +73,7 @@ Typical first-run workflow:
 │   ├── settings.php
 │   └── ...
 ├── mobiskel.js          # JS enhancements (e.g., menu)
+</pre>
 
 **Profile Art Credits**
 Our iconic alien mascot was born from a prompt by @deadlydud & @Aither,


### PR DESCRIPTION
## Summary
- introduce `AGENTS.mb` to explain Codex-Ae
- wrap README file tree in `<pre>` to retain layout
- ignore PHPUnit cache

## Testing
- `phpunit tests/test_clean_all_inputs.php` *(fails: `clean_all_inputs` undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6863cbf080f0832db8a4c6dcb527c1e8